### PR TITLE
feat(PHP Upgrade): add PHP 8.4 support

### DIFF
--- a/lib/Shift4/Shift4Gateway.php
+++ b/lib/Shift4/Shift4Gateway.php
@@ -29,7 +29,7 @@ class Shift4Gateway
 
     private $userAgent;
 
-    public function __construct($privateKey = null, Connection $connection = null)
+    public function __construct($privateKey = null, ?Connection $connection = null)
     {
         $this->objectSerializer = new ObjectSerializer();
 
@@ -41,7 +41,7 @@ class Shift4Gateway
      * @param \Shift4\Request\ChargeRequest $request
      * @return \Shift4\Response\Charge
      */
-    public function createCharge($request, RequestOptions $requestOptions = null)
+    public function createCharge($request, ?RequestOptions $requestOptions = null)
     {
         return $this->post('/charges', $request, '\Shift4\Response\Charge', $requestOptions);
     }
@@ -50,7 +50,7 @@ class Shift4Gateway
      * @param \Shift4\Request\CaptureRequest $request
      * @return \Shift4\Response\Charge
      */
-    public function captureCharge($request, RequestOptions $requestOptions = null)
+    public function captureCharge($request, ?RequestOptions $requestOptions = null)
     {
         return $this->post('/charges/{chargeId}/capture', $request, '\Shift4\Response\Charge', $requestOptions);
     }
@@ -68,7 +68,7 @@ class Shift4Gateway
      * @param \Shift4\Request\ChargeUpdateRequest $request
      * @return \Shift4\Response\Charge
      */
-    public function updateCharge($request, RequestOptions $requestOptions = null)
+    public function updateCharge($request, ?RequestOptions $requestOptions = null)
     {
         return $this->post('/charges/{chargeId}', $request, '\Shift4\Response\Charge', $requestOptions);
     }
@@ -79,7 +79,7 @@ class Shift4Gateway
      *
      * @deprecated For backward compatibility only. Use "createRefund($request)".
      */
-    public function refundCharge($request, RequestOptions $requestOptions = null)
+    public function refundCharge($request, ?RequestOptions $requestOptions = null)
     {
         return $this->createRefund($request, $requestOptions);
     }
@@ -97,7 +97,7 @@ class Shift4Gateway
      * @param \Shift4\Request\CustomerRequest $request
      * @return \Shift4\Response\Customer
      */
-    public function createCustomer($request, RequestOptions $requestOptions = null)
+    public function createCustomer($request, ?RequestOptions $requestOptions = null)
     {
         return $this->post('/customers', $request, '\Shift4\Response\Customer', $requestOptions);
     }
@@ -115,7 +115,7 @@ class Shift4Gateway
      * @param \Shift4\Request\CustomerUpdateRequest $request
      * @return \Shift4\Response\Customer
      */
-    public function updateCustomer($request, RequestOptions $requestOptions = null)
+    public function updateCustomer($request, ?RequestOptions $requestOptions = null)
     {
         return $this->post('/customers/{customerId}', $request, '\Shift4\Response\Customer', $requestOptions);
     }
@@ -142,7 +142,7 @@ class Shift4Gateway
      * @param \Shift4\Request\CardRequest $request
      * @return \Shift4\Response\Card
      */
-    public function createCard($request, RequestOptions $requestOptions = null)
+    public function createCard($request, ?RequestOptions $requestOptions = null)
     {
         return $this->post('/customers/{customerId}/cards', $request, '\Shift4\Response\Card', $requestOptions);
     }
@@ -161,7 +161,7 @@ class Shift4Gateway
      * @param \Shift4\Request\CardUpdateRequest $request
      * @return \Shift4\Response\Card
      */
-    public function updateCard($request, RequestOptions $requestOptions = null)
+    public function updateCard($request, ?RequestOptions $requestOptions = null)
     {
         return $this->post('/customers/{customerId}/cards/{cardId}', $request, '\Shift4\Response\Card', $requestOptions);
     }
@@ -198,7 +198,7 @@ class Shift4Gateway
      * @param \Shift4\Request\PaymentMethodRequest $request
      * @return \Shift4\Response\PaymentMethod
      */
-    public function createPaymentMethod($request, RequestOptions $requestOptions = null)
+    public function createPaymentMethod($request, ?RequestOptions $requestOptions = null)
     {
         return $this->post("/payment-methods", $request, '\Shift4\Response\PaymentMethod', $requestOptions);
     }
@@ -225,7 +225,7 @@ class Shift4Gateway
      * @param \Shift4\Request\SubscriptionRequest $request
      * @return \Shift4\Response\Subscription
      */
-    public function createSubscription($request, RequestOptions $requestOptions = null)
+    public function createSubscription($request, ?RequestOptions $requestOptions = null)
     {
         return $this->post('/customers/{customerId}/subscriptions', $request, '\Shift4\Response\Subscription', $requestOptions);
     }
@@ -244,7 +244,7 @@ class Shift4Gateway
      * @param \Shift4\Request\SubscriptionUpdateRequest $request
      * @return \Shift4\Response\Subscription
      */
-    public function updateSubscription($request, RequestOptions $requestOptions = null)
+    public function updateSubscription($request, ?RequestOptions $requestOptions = null)
     {
         return $this->post('/customers/{customerId}/subscriptions/{subscriptionId}', $request, '\Shift4\Response\Subscription', $requestOptions);
     }
@@ -271,7 +271,7 @@ class Shift4Gateway
      * @param \Shift4\Request\PlanRequest $request
      * @return \Shift4\Response\Plan
      */
-    public function createPlan($request, RequestOptions $requestOptions = null)
+    public function createPlan($request, ?RequestOptions $requestOptions = null)
     {
         return $this->post('/plans', $request, '\Shift4\Response\Plan', $requestOptions);
     }
@@ -289,7 +289,7 @@ class Shift4Gateway
      * @param \Shift4\Request\PlanUpdateRequest $request
      * @return \Shift4\Response\Plan
      */
-    public function updatePlan($request, RequestOptions $requestOptions = null)
+    public function updatePlan($request, ?RequestOptions $requestOptions = null)
     {
         return $this->post('/plans/{planId}', $request, '\Shift4\Response\Plan', $requestOptions);
     }
@@ -352,7 +352,7 @@ class Shift4Gateway
      * @param \Shift4\Request\BlacklistRuleRequest $request
      * @return \Shift4\Response\BlacklistRule
      */
-    public function createBlacklistRule($request, RequestOptions $requestOptions = null)
+    public function createBlacklistRule($request, ?RequestOptions $requestOptions = null)
     {
         return $this->post('/blacklist', $request, '\Shift4\Response\BlacklistRule', $requestOptions);
     }
@@ -388,7 +388,7 @@ class Shift4Gateway
      * @param \Shift4\Request\CreditRequest $request
      * @return \Shift4\Response\Credit
      */
-    public function createCredit($request, RequestOptions $requestOptions = null)
+    public function createCredit($request, ?RequestOptions $requestOptions = null)
     {
         return $this->post('/credits', $request, '\Shift4\Response\Credit', $requestOptions);
     }
@@ -406,7 +406,7 @@ class Shift4Gateway
      * @param \Shift4\Request\CreditUpdateRequest $request
      * @return \Shift4\Response\Credit
      */
-    public function updateCredit($request, RequestOptions $requestOptions = null)
+    public function updateCredit($request, ?RequestOptions $requestOptions = null)
     {
         return $this->post('/credits/{creditId}', $request, '\Shift4\Response\Credit', $requestOptions);
     }
@@ -464,7 +464,7 @@ class Shift4Gateway
      * @param \Shift4\Request\DisputeUpdateRequest $request
      * @return \Shift4\Response\Dispute
      */
-    public function updateDispute($request, RequestOptions $requestOptions = null)
+    public function updateDispute($request, ?RequestOptions $requestOptions = null)
     {
         return $this->post('/disputes/{disputeId}', $request, '\Shift4\Response\Dispute', $requestOptions);
     }
@@ -473,7 +473,7 @@ class Shift4Gateway
      * @param string $disputeId
      * @return \Shift4\Response\Dispute
      */
-    public function closeDispute($disputeId, RequestOptions $requestOptions = null)
+    public function closeDispute($disputeId, ?RequestOptions $requestOptions = null)
     {
         return $this->post("/disputes/{$disputeId}/close", null, '\Shift4\Response\Dispute', $requestOptions);
     }
@@ -518,7 +518,7 @@ class Shift4Gateway
      * @param \Shift4\Request\RefundRequest $request
      * @return \Shift4\Response\Refund
      */
-    public function createRefund($request, RequestOptions $requestOptions = null)
+    public function createRefund($request, ?RequestOptions $requestOptions = null)
     {
         return $this->post('/refunds', $request, '\Shift4\Response\Refund', $requestOptions);
     }
@@ -593,7 +593,7 @@ class Shift4Gateway
         return $this->objectSerializer->deserialize($response['body'], $responseClass);
     }
 
-    private function post($path, $request, $responseClass, RequestOptions $requestOptions = null)
+    private function post($path, $request, $responseClass, ?RequestOptions $requestOptions = null)
     {
         $requestBody = $this->objectSerializer->serialize($request, $path);
         $response = $this->connection->post($this->endpoint . $path, $requestBody, $this->buildHeaders($requestOptions));
@@ -648,7 +648,7 @@ class Shift4Gateway
         return $path . $queryString;
     }
 
-    private function buildHeaders(RequestOptions $requestOptions = null)
+    private function buildHeaders(?RequestOptions $requestOptions = null)
     {
         $headers = [
             'Authorization' => 'Basic ' . base64_encode($this->privateKey . ':'),


### PR DESCRIPTION
Minimal changes to support php 8.4 on shift4
`Shift4\Shift4Gateway::__construct(): Implicitly marking parameter $connection as nullable is deprecated, the explicit nullable type must be used instead`